### PR TITLE
decode encoded links in email

### DIFF
--- a/lib/email_spec/helpers.rb
+++ b/lib/email_spec/helpers.rb
@@ -76,7 +76,8 @@ module EmailSpec
     end
 
     def links_in_email(email)
-      URI.extract(email.default_part_body.to_s, ['http', 'https'])
+      links = URI.extract(email.default_part_body.to_s, ['http', 'https'])
+      links.map{|url| HTMLEntities.new.decode(url) }.uniq
     end
 
     private


### PR DESCRIPTION
when the email is HTML the urls are html encoded and need to be decoded